### PR TITLE
Improve home screen ui

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,7 @@ class MyApp extends StatelessWidget {
 
       theme: ThemeData(
         brightness: Brightness.light,
-        primaryColor: Colors.grey[200],
+        primaryColor: Colors.grey[100],
         accentColor: Colors.redAccent,
         textTheme: TextTheme(
           headline: TextStyle(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -8,13 +8,9 @@ import 'package:superhero_app/screens/search.dart';
 import 'package:superhero_app/screens/settings.dart';
 import 'package:superhero_app/widget/superhero.dart';
 
-
 class Home extends StatefulWidget {
   final String title;
-  Home({
-    Key key,
-    this.title
-  }) : super(key: key);
+  Home({Key key, this.title}) : super(key: key);
 
   @override
   _HomeState createState() => _HomeState();
@@ -24,8 +20,7 @@ class _HomeState extends State<Home> {
   List responseList;
 
   bool _loading;
-  getHeroes() async{
-
+  getHeroes() async {
     setState(() {
       _loading = true;
     });
@@ -35,18 +30,15 @@ class _HomeState extends State<Home> {
     List decodedJson = jsonDecode(res.body);
 
     int code = response.statusCode;
-    if(code == 200){
-
+    if (code == 200) {
       setState(() {
         responseList = decodedJson;
         _loading = false;
       });
-    }else{
+    } else {
       print("Something went wrong");
     }
-
   }
-
 
   @override
   void initState() {
@@ -69,26 +61,26 @@ class _HomeState extends State<Home> {
         actions: <Widget>[
           IconButton(
             icon: Icon(Icons.search),
-            onPressed: (){
-
-              responseList == null ? print("Chill")
-                  :
-              showSearch(
-                context: context,
-                delegate: HeroSearch(all: responseList),
-              );
+            onPressed: () {
+              responseList == null
+                  ? print("Chill")
+                  : showSearch(
+                      context: context,
+                      delegate: HeroSearch(all: responseList),
+                    );
             },
             tooltip: "Search",
             color: Colors.black,
           ),
           IconButton(
             icon: Icon(Icons.settings),
-            onPressed: (){
-              var router = new MaterialPageRoute(
-                  builder: (BuildContext context) {
-                    return Settings(title: widget.title,);
-                  }
-              );
+            onPressed: () {
+              var router =
+                  new MaterialPageRoute(builder: (BuildContext context) {
+                return Settings(
+                  title: widget.title,
+                );
+              });
 
               Navigator.of(context).push(router);
             },
@@ -98,35 +90,33 @@ class _HomeState extends State<Home> {
         ],
       ),
       backgroundColor: Colors.grey[200],
-
       body: _loading
           ? Center(
-        child: CircularProgressIndicator(
-          valueColor: AlwaysStoppedAnimation<Color>(Colors.red),
-        ),
-      )
-          :Padding(
-        padding: EdgeInsets.all(10.0),
-        child: ListView.builder(
-          shrinkWrap: true,
-          itemCount: responseList == null ? 0 : responseList.length,
-          itemBuilder: (BuildContext context, int index) {
-            HeroItem heroItem = HeroItem.fromJson(responseList[index]);
+              child: CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.red),
+              ),
+            )
+          : Padding(
+              padding: EdgeInsets.all(10.0),
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: responseList == null ? 0 : responseList.length,
+                itemBuilder: (BuildContext context, int index) {
+                  HeroItem heroItem = HeroItem.fromJson(responseList[index]);
 
-            return SuperHero(
-              name: heroItem.name,
-              fullName: heroItem.biography.fullName,
-              race: heroItem.appearance.race,
-              publisher: heroItem.biography.publisher,
-              id: heroItem.id,
-              hairColor: heroItem.appearance.hairColor,
-              gender: heroItem.appearance.gender,
-              img: heroItem.images.lg,
-            );
-          },
-
-        ),
-      ),
+                  return SuperHero(
+                    name: heroItem.name,
+                    fullName: heroItem.biography.fullName,
+                    race: heroItem.appearance.race,
+                    publisher: heroItem.biography.publisher,
+                    id: heroItem.id,
+                    hairColor: heroItem.appearance.hairColor,
+                    gender: heroItem.appearance.gender,
+                    img: heroItem.images.lg,
+                  );
+                },
+              ),
+            ),
     );
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -51,7 +51,6 @@ class _HomeState extends State<Home> {
     return Scaffold(
       appBar: AppBar(
         elevation: 0.0,
-        backgroundColor: Colors.grey[200],
         title: Text(
           "${widget.title.toUpperCase()}",
           style: TextStyle(
@@ -89,7 +88,7 @@ class _HomeState extends State<Home> {
           ),
         ],
       ),
-      backgroundColor: Colors.grey[200],
+      backgroundColor: Theme.of(context).primaryColor,
       body: _loading
           ? Center(
               child: CircularProgressIndicator(
@@ -97,22 +96,25 @@ class _HomeState extends State<Home> {
               ),
             )
           : Padding(
-              padding: EdgeInsets.all(10.0),
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
               child: ListView.builder(
                 shrinkWrap: true,
                 itemCount: responseList == null ? 0 : responseList.length,
                 itemBuilder: (BuildContext context, int index) {
                   HeroItem heroItem = HeroItem.fromJson(responseList[index]);
 
-                  return SuperHero(
-                    name: heroItem.name,
-                    fullName: heroItem.biography.fullName,
-                    race: heroItem.appearance.race,
-                    publisher: heroItem.biography.publisher,
-                    id: heroItem.id,
-                    hairColor: heroItem.appearance.hairColor,
-                    gender: heroItem.appearance.gender,
-                    img: heroItem.images.lg,
+                  return Padding(
+                    padding: const EdgeInsets.all(2.0),
+                    child: SuperHero(
+                      name: heroItem.name,
+                      fullName: heroItem.biography.fullName,
+                      race: heroItem.appearance.race,
+                      publisher: heroItem.biography.publisher,
+                      id: heroItem.id,
+                      hairColor: heroItem.appearance.hairColor,
+                      gender: heroItem.appearance.gender,
+                      img: heroItem.images.lg,
+                    ),
                   );
                 },
               ),

--- a/lib/widget/superhero.dart
+++ b/lib/widget/superhero.dart
@@ -36,6 +36,7 @@ class SuperHero extends StatelessWidget {
         Navigator.of(context).push(router);
       },
       child: Card(
+        color: Colors.white.withOpacity(0.9),
         clipBehavior: Clip.antiAlias,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10.0),
@@ -60,7 +61,7 @@ class SuperHero extends StatelessWidget {
                         ),
                         boxShadow: [
                           BoxShadow(
-                              color: Colors.grey.withOpacity(1.0),
+                              color: Colors.grey.withOpacity(0.3),
                               offset: new Offset(0.0, 0.0),
                               blurRadius: 2.0,
                               spreadRadius: 0.0),

--- a/lib/widget/superhero.dart
+++ b/lib/widget/superhero.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:superhero_app/screens/details.dart';
 
-
 class SuperHero extends StatelessWidget {
   var id;
   var name;
@@ -29,143 +28,111 @@ class SuperHero extends StatelessWidget {
     return Padding(
       padding: EdgeInsets.only(right: 5.0, left: 5.0, top: 5.0),
       child: InkWell(
-        onTap: (){
-          var router = new MaterialPageRoute(
-              builder: (BuildContext context) {
-                return Details(img: img, id: id);
-              }
-          );
+        onTap: () {
+          var router = new MaterialPageRoute(builder: (BuildContext context) {
+            return Details(img: img, id: id);
+          });
 
           Navigator.of(context).push(router);
         },
         child: Card(
           elevation: 6.0,
-          child: Row(
-            children: <Widget>[
-
-
-              ClipRRect(
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(20.0),
-                  bottomLeft: Radius.circular(20.0),
-                ),
-                child: SizedBox(
-                  child: Image.network(
-                    "$img",
-                    fit: BoxFit.fill,
-
-                  ),
-                  width: MediaQuery.of(context).size.width /2.7,
-                ),
-              ),
-
-
-              Padding(
-                padding: EdgeInsets.only(
-                  left: 20.0,
-                  right: 10.0,
-                  top: 20.0,
-                  bottom: 20.0,
-                ),
-                child: Container(
-                  width: MediaQuery.of(context).size.width /2.3,
-                  child: Align(
-                    child: Column(
-                      children: <Widget>[
-
-                        Container(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            "$name",
-                            style: TextStyle(
-                              fontSize: 18.0,
-                              fontWeight: FontWeight.bold,
-                            ),
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-
-
-                        SizedBox(height: 10.0),
-
-                        Container(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            "$fullName",
-                            style: TextStyle(
-                              fontSize: 13.0,
-                              fontWeight: FontWeight.w700,
-                            ),
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-
-                        SizedBox(height: 10.0),
-
-                        Container(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            "Race: ${race == null ? "Unknown" : race}",
-                            style: TextStyle(
-                              fontSize: 13.0,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-
-
-                        Container(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            "Gender: $gender",
-                            style: TextStyle(
-                              fontSize: 13.0,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-
-
-                        Container(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            "Hair Color: $hairColor",
-                            style: TextStyle(
-                              fontSize: 13.0,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-
-
-                        Container(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            "By $publisher",
-                            style: TextStyle(
-                              fontSize: 13.0,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            textAlign: TextAlign.left,
-                          ),
-                        ),
-
-
-
-                      ],
+          clipBehavior: Clip.antiAlias,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10.0),
+          ),
+          child: Container(
+            color: Colors.amber,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: CircleAvatar(
+                    radius: 50.0,
+                    backgroundImage: NetworkImage(
+                      "$img",
                     ),
                   ),
                 ),
-              ),
-            ],
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(20.0),
-              bottomLeft: Radius.circular(20.0),
+                Container(
+                  color: Colors.green,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Container(
+                        alignment: Alignment.topLeft,
+                        child: Text(
+                          "$name",
+                          style: TextStyle(
+                            fontSize: 18.0,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.left,
+                        ),
+                      ),
+                      Container(
+                        alignment: Alignment.topLeft,
+                        child: Text(
+                          "$fullName",
+                          style: TextStyle(
+                            fontSize: 16.0,
+                            fontWeight: FontWeight.w300,
+                          ),
+                          textAlign: TextAlign.left,
+                        ),
+                      ),
+                      // SizedBox(height: 10.0),
+                      // Container(
+                      //   alignment: Alignment.topLeft,
+                      //   child: Text(
+                      //     "Race: ${race == null ? "Unknown" : race}",
+                      //     style: TextStyle(
+                      //       fontSize: 13.0,
+                      //       fontWeight: FontWeight.w500,
+                      //     ),
+                      //     textAlign: TextAlign.left,
+                      //   ),
+                      // ),
+                      // Container(
+                      //   alignment: Alignment.topLeft,
+                      //   child: Text(
+                      //     "Gender: $gender",
+                      //     style: TextStyle(
+                      //       fontSize: 13.0,
+                      //       fontWeight: FontWeight.w500,
+                      //     ),
+                      //     textAlign: TextAlign.left,
+                      //   ),
+                      // ),
+                      // Container(
+                      //   alignment: Alignment.topLeft,
+                      //   child: Text(
+                      //     "Hair Color: $hairColor",
+                      //     style: TextStyle(
+                      //       fontSize: 13.0,
+                      //       fontWeight: FontWeight.w500,
+                      //     ),
+                      //     textAlign: TextAlign.left,
+                      //   ),
+                      // ),
+                      Container(
+                        alignment: Alignment.topLeft,
+                        child: Text(
+                          "By $publisher",
+                          style: TextStyle(
+                            fontSize: 13.0,
+                            fontWeight: FontWeight.w500,
+                          ),
+                          textAlign: TextAlign.left,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/widget/superhero.dart
+++ b/lib/widget/superhero.dart
@@ -3,8 +3,8 @@ import 'package:superhero_app/screens/details.dart';
 
 class SuperHero extends StatelessWidget {
   var id;
-  var name;
-  var fullName;
+  String name;
+  String fullName;
   var img;
   var race;
   var gender;
@@ -25,117 +25,81 @@ class SuperHero extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(right: 5.0, left: 5.0, top: 5.0),
-      child: InkWell(
-        onTap: () {
-          var router = new MaterialPageRoute(builder: (BuildContext context) {
-            return Details(img: img, id: id);
-          });
+    TextTheme textTheme = Theme.of(context).textTheme;
 
-          Navigator.of(context).push(router);
-        },
-        child: Card(
-          elevation: 6.0,
-          clipBehavior: Clip.antiAlias,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10.0),
-          ),
-          child: Container(
-            color: Colors.amber,
+    return InkWell(
+      onTap: () {
+        var router = new MaterialPageRoute(builder: (BuildContext context) {
+          return Details(img: img, id: id);
+        });
+
+        Navigator.of(context).push(router);
+      },
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10.0),
+        ),
+        child: Container(
+            child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: IntrinsicHeight(
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: CircleAvatar(
-                    radius: 50.0,
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  SizedBox(
+                    width: 12.0,
+                  ),
+                  CircleAvatar(
+                    radius: 40.0,
                     backgroundImage: NetworkImage(
                       "$img",
                     ),
                   ),
-                ),
-                Container(
-                  color: Colors.green,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Container(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          "$name",
-                          style: TextStyle(
-                            fontSize: 18.0,
-                            fontWeight: FontWeight.bold,
-                          ),
-                          textAlign: TextAlign.left,
-                        ),
-                      ),
-                      Container(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          "$fullName",
-                          style: TextStyle(
-                            fontSize: 16.0,
-                            fontWeight: FontWeight.w300,
-                          ),
-                          textAlign: TextAlign.left,
-                        ),
-                      ),
-                      // SizedBox(height: 10.0),
-                      // Container(
-                      //   alignment: Alignment.topLeft,
-                      //   child: Text(
-                      //     "Race: ${race == null ? "Unknown" : race}",
-                      //     style: TextStyle(
-                      //       fontSize: 13.0,
-                      //       fontWeight: FontWeight.w500,
-                      //     ),
-                      //     textAlign: TextAlign.left,
-                      //   ),
-                      // ),
-                      // Container(
-                      //   alignment: Alignment.topLeft,
-                      //   child: Text(
-                      //     "Gender: $gender",
-                      //     style: TextStyle(
-                      //       fontSize: 13.0,
-                      //       fontWeight: FontWeight.w500,
-                      //     ),
-                      //     textAlign: TextAlign.left,
-                      //   ),
-                      // ),
-                      // Container(
-                      //   alignment: Alignment.topLeft,
-                      //   child: Text(
-                      //     "Hair Color: $hairColor",
-                      //     style: TextStyle(
-                      //       fontSize: 13.0,
-                      //       fontWeight: FontWeight.w500,
-                      //     ),
-                      //     textAlign: TextAlign.left,
-                      //   ),
-                      // ),
-                      Container(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          "By $publisher",
-                          style: TextStyle(
-                            fontSize: 13.0,
-                            fontWeight: FontWeight.w500,
-                          ),
-                          textAlign: TextAlign.left,
-                        ),
-                      ),
-                    ],
+                  SizedBox(
+                    width: 24.0,
                   ),
-                ),
-              ],
-            ),
+                  Expanded(
+                    child: Container(
+                      // color: Colors.indigo,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            "$name",
+                            style: textTheme.title,
+                          ),
+                          Text(
+                            fullName.isEmpty ? name : fullName,
+                            style: textTheme.subtitle.copyWith(
+                              fontWeight: FontWeight.w300,
+                            ),
+                          ),
+                          Row(
+                            children: <Widget>[
+                              Icon(
+                                Icons.book,
+                                color: Colors.black54,
+                                size: 18.0,
+                              ),
+                              SizedBox(
+                                width: 2.0,
+                              ),
+                              Text(
+                                "$publisher",
+                                style: textTheme.caption,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                ]),
           ),
-        ),
+        )),
       ),
     );
   }

--- a/lib/widget/superhero.dart
+++ b/lib/widget/superhero.dart
@@ -51,10 +51,28 @@ class SuperHero extends StatelessWidget {
                   SizedBox(
                     width: 12.0,
                   ),
-                  CircleAvatar(
-                    radius: 40.0,
-                    backgroundImage: NetworkImage(
-                      "$img",
+                  Container(
+                    decoration: BoxDecoration(
+                        color: Colors.white,
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: Colors.transparent,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                              color: Colors.grey.withOpacity(1.0),
+                              offset: new Offset(0.0, 0.0),
+                              blurRadius: 2.0,
+                              spreadRadius: 0.0),
+                        ]),
+                    child: Padding(
+                      padding: const EdgeInsets.all(4.0),
+                      child: CircleAvatar(
+                        radius: 40.0,
+                        backgroundImage: NetworkImage(
+                          "$img",
+                        ),
+                      ),
                     ),
                   ),
                   SizedBox(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.5"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR improves the UI of the home screen by reducing the number of information in each superhero card widget. It also changes the superhero image from a full image to a circle avatar. This is done to achieve a cleaner UI.

Below are screenshots of the new look:

On iOS
![Simulator Screen Shot - iPhone Xʀ - 2019-05-15 at 22 01 20](https://user-images.githubusercontent.com/19398044/57809846-5056ae80-775e-11e9-8d40-282a66c43baa.png)

On Android
![Screenshot_1557954551](https://user-images.githubusercontent.com/19398044/57809856-5ba9da00-775e-11e9-9a04-07587d13ff13.png)

